### PR TITLE
feat: Add promise support for trId

### DIFF
--- a/payzeApplePay.bundle.js
+++ b/payzeApplePay.bundle.js
@@ -110,12 +110,14 @@ function PayzeApplePay(merchantIdentifier, _ref) {
 
     session.onvalidatemerchant = /*#__PURE__*/function () {
       var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee(event) {
+        var _promisedTrId;
+
         var merchantSession;
         return _regeneratorRuntime().wrap(function _callee$(_context) {
           while (1) {
             switch (_context.prev = _context.next) {
               case 0:
-                merchantSession = validateMerchant(trId);
+                merchantSession = validateMerchant((_promisedTrId = promisedTrId) !== null && _promisedTrId !== void 0 ? _promisedTrId : trId);
                 merchantSession.then(function (response) {
                   response.json().then(function (data) {
                     applePayToken = data.data.token;
@@ -156,14 +158,14 @@ function PayzeApplePay(merchantIdentifier, _ref) {
     };
 
     session.onpaymentauthorized = function (event) {
-      var _promisedTrId;
+      var _promisedTrId2;
 
       var token = event.payment.token;
       var acceptApplePay = fetch("".concat(BASE_URL, "/accept"), {
         method: "POST",
         body: JSON.stringify({
           token: applePayToken,
-          payzeTransactionId: (_promisedTrId = promisedTrId) !== null && _promisedTrId !== void 0 ? _promisedTrId : trId,
+          payzeTransactionId: (_promisedTrId2 = promisedTrId) !== null && _promisedTrId2 !== void 0 ? _promisedTrId2 : trId,
           acceptRequest: {
             version: token.paymentData.version,
             data: token.paymentData.data,

--- a/payzeApplePay.bundle.js
+++ b/payzeApplePay.bundle.js
@@ -80,7 +80,7 @@ function PayzeApplePay(merchantIdentifier, _ref) {
   /**
   * Make Payze Apple Pay With TransactionId
   *
-  * @param {string} trId  Transaction ID or promise that returns it.
+  * @param {(string|Promise<string>)} trId  Transaction ID or promise that returns it.
   * 
   */
 

--- a/payzeApplePay.bundle.js
+++ b/payzeApplePay.bundle.js
@@ -212,7 +212,7 @@ function PayzeApplePay(merchantIdentifier, _ref) {
     if (typeof trId === 'string') {
       session.begin();
     } else {
-      return trId().then(function (id) {
+      return trId.then(function (id) {
         promisedTrId = id;
         session.begin();
       }).catch(function (error) {

--- a/payzeApplePay.d.ts
+++ b/payzeApplePay.d.ts
@@ -11,5 +11,5 @@
  */
 
 export function PayzeApplePay(merchantIdentifier: string, config: any, callback?: any): {
-  makeApplePay: (trId: string) => void;
+  makeApplePay: (trId: Promise<string> | string) => Promise<void>;
 };

--- a/payzeApplePay.js
+++ b/payzeApplePay.js
@@ -69,7 +69,7 @@ function PayzeApplePay(merchantIdentifier, { amount, currencyCode, label }, call
   /**
   * Make Payze Apple Pay With TransactionId
   *
-  * @param {string} trId  Transaction ID or promise that returns it.
+  * @param {(string|Promise<string>)} trId  Transaction ID or promise that returns it.
   * 
   */
   function makeApplePay(trId) {

--- a/payzeApplePay.js
+++ b/payzeApplePay.js
@@ -95,7 +95,7 @@ function PayzeApplePay(merchantIdentifier, { amount, currencyCode, label }, call
     const session = new (window).ApplePaySession(10, request);
 
     session.onvalidatemerchant = async (event) => {
-      const merchantSession = validateMerchant(trId);
+      const merchantSession = validateMerchant(promisedTrId ?? trId);
       merchantSession.then((response) => {
         response.json().then((data) => {
           applePayToken = data.data.token;

--- a/payzeApplePay.js
+++ b/payzeApplePay.js
@@ -182,7 +182,7 @@ function PayzeApplePay(merchantIdentifier, { amount, currencyCode, label }, call
     if (typeof trId === 'string') {
       session.begin()
     } else {
-      return trId().then((id) => {
+      return trId.then((id) => {
         promisedTrId = id
         session.begin()
       })


### PR DESCRIPTION
In most cases Payze order should be created when user clicks on ApplePay button. Because this operation is asynchronous ApplePay session should be started after its completion.